### PR TITLE
✨ feat: 디스코드 뉴스 요약 API 기능 추가

### DIFF
--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,9 +1,9 @@
 from fastapi import APIRouter
-from app.api.v1.endpoints import chat_router
-from app.api.v1.endpoints import chat_router, notice_router 
+from app.api.v1.endpoints import chat_router, notice_router, discordnews_router
 
 api_router = APIRouter(prefix="/api")
 
 # 버전 관리
 api_router.include_router(chat_router.router, prefix="/v1")
 api_router.include_router(notice_router.router, prefix="/v1")
+api_router.include_router(discordnews_router.router, prefix="/v1")

--- a/app/api/v1/controllers/discordnews_controller.py
+++ b/app/api/v1/controllers/discordnews_controller.py
@@ -1,0 +1,12 @@
+from app.schemas.discordnews_schema import DiscordNewsRequest, DiscordNewsResponse
+from app.services.discordnews_service import summarize_discord_news_service
+
+async def summarize_discord_news(request: DiscordNewsRequest) -> dict:
+    headline, summary = await summarize_discord_news_service(request.title, request.content)
+    return {
+        "message": "뉴스 헤드라인, 요약 생성이 완료되었습니다.",
+        "data": {
+            "headline": headline,
+            "summary": summary
+        }
+    }

--- a/app/api/v1/endpoints/discordnews_router.py
+++ b/app/api/v1/endpoints/discordnews_router.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+from app.schemas.discordnews_schema import DiscordNewsRequest, DiscordNewsResponse
+from app.api.v1.controllers.discordnews_controller import summarize_discord_news
+from typing import Dict, Any
+
+router = APIRouter()
+
+@router.post("/news", response_model=Dict[str, Any])
+async def discord_news_endpoint(request: DiscordNewsRequest):
+    return await summarize_discord_news(request)

--- a/app/schemas/discordnews_schema.py
+++ b/app/schemas/discordnews_schema.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class DiscordNewsRequest(BaseModel):
+    title: Optional[str] = None  # 선택값
+    content: str                # 필수값
+
+class DiscordNewsResponse(BaseModel):
+    headline: str
+    summary: str

--- a/app/services/discordnews_service.py
+++ b/app/services/discordnews_service.py
@@ -1,0 +1,16 @@
+from app.model.generate import generate_response
+
+async def summarize_discord_news_service(title: str | None, content: str) -> tuple[str, str]:
+    # 제목이 없다면 content 일부를 headline에 사용
+    if title:
+        headline_prompt = f"[헤드라인 생성]\n{title}"
+    else:
+        headline_prompt = f"[헤드라인 생성]\n{content[:30]}..."
+
+    summary_prompt = f"[요약 생성]\n{content}"
+
+    # 현재는 dummy 응답으로 처리
+    headline = await generate_response(headline_prompt)
+    summary = await generate_response(summary_prompt)
+
+    return headline, summary


### PR DESCRIPTION
### Description

디스코드 소통방 메시지를 기반으로 뉴스 헤드라인과 요약을 생성하는 API를 구현했습니다.  
현재는 더미(Echo) 기반 응답이며, LLM 연동은 이후에 추가될 예정입니다.

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. POST /api/v1/news 라우터 추가
2. discordnews controller/service/schema 구성
3. 더미 기반 텍스트 생성 로직 구현
4. 명세서에 맞춘 응답 포맷 적용 (`message + data.headline/summary`)

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. Swagger UI에서 정상 요청/응답 확인
2. title 미입력 케이스도 정상 처리
3. 응답 구조 및 상태코드 명세서와 일치 확인

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

