### PR TITLE
♻️ refactor: LLM 호출부 비동기 처리 통일 (#55)

### DIFF
--- a/app/api/v1/controllers/discordnews_controller.py
+++ b/app/api/v1/controllers/discordnews_controller.py
@@ -1,9 +1,9 @@
 from app.schemas.discordnews_schema import DiscordNewsRequest, DiscordNewsResponse, DiscordNewsData
 from app.services.discordnews_service import summarize_discord_news_service
 
-def summarize_discord_news(request: DiscordNewsRequest) -> DiscordNewsResponse:
+async def summarize_discord_news(request: DiscordNewsRequest) -> DiscordNewsResponse:
     # 뉴스 요약 서비스 호출
-    headline, summary, isCompleted = summarize_discord_news_service(request.title, request.content)
+    headline, summary, isCompleted = await summarize_discord_news_service(request.title, request.content)
 
     # 표준 응답 스키마로 래핑하여 반환
     return DiscordNewsResponse(

--- a/app/api/v1/controllers/notice_controller.py
+++ b/app/api/v1/controllers/notice_controller.py
@@ -1,8 +1,8 @@
 from app.services.notice_service import summarize_notice_service
 from app.schemas.notice_schema import NoticeRequest, NoticeResponse, NoticeData
 
-def summarize_notice(request: NoticeRequest) -> NoticeResponse:
-    summary, isCompleted = summarize_notice_service(request.title, request.content)
+async def summarize_notice(request: NoticeRequest) -> NoticeResponse:
+    summary, isCompleted = await summarize_notice_service(request.title, request.content)
 
     return NoticeResponse(
         message="공지사항 요약이 완료되었습니다.",

--- a/app/api/v1/endpoints/discordnews_router.py
+++ b/app/api/v1/endpoints/discordnews_router.py
@@ -6,6 +6,6 @@ router = APIRouter()
 
 # Discord 뉴스 요약 API 엔드포인트
 @router.post("/news", response_model=DiscordNewsResponse)
-def discord_news_endpoint(request: DiscordNewsRequest):
+async def discord_news_endpoint(request: DiscordNewsRequest):
     # 뉴스 요약 컨트롤러 호출
-    return summarize_discord_news(request)
+    return await summarize_discord_news(request)

--- a/app/api/v1/endpoints/notice_router.py
+++ b/app/api/v1/endpoints/notice_router.py
@@ -6,6 +6,6 @@ router = APIRouter()
 
 # 공지사항 요약 API 엔드포인트
 @router.post("/notices/summarization", response_model=NoticeResponse)
-def notice_endpoint(request: NoticeRequest):
+async def notice_endpoint(request: NoticeRequest):
     # 공지 요약 컨트롤러 호출
-    return summarize_notice(request)
+    return await summarize_notice(request)

--- a/app/core/llm_client.py
+++ b/app/core/llm_client.py
@@ -36,6 +36,6 @@ async def get_chat_response(question: str) -> str:
     return await llm.ainvoke(prompt_str)
 
 # 요약/뉴스 생성: 단일 프롬프트 동기 호출
-def call_qwen(prompt: str) -> str:
+async def call_qwen(prompt: str) -> str:
     prompt_str = build_prompt(prompt)
-    return llm.invoke(prompt_str)
+    return await llm.ainvoke(prompt_str)

--- a/app/services/discordnews_service.py
+++ b/app/services/discordnews_service.py
@@ -2,7 +2,7 @@ import json
 from app.core.llm_client import call_qwen
 from app.model.prompt_template import discord_news_prompt
 
-def summarize_discord_news_service(title: str | None, content: str) -> tuple[str, str]:
+async def summarize_discord_news_service(title: str | None, content: str) -> tuple[str, str]:
     # 1. 템플릿 적용
     prompt = discord_news_prompt.format(docs=content)
 
@@ -21,4 +21,4 @@ def summarize_discord_news_service(title: str | None, content: str) -> tuple[str
         headline = "헤드라인 없음"
         summary = "요약 생성 실패"
 
-    return headline, summary, isCompleted
+    return await headline, summary, isCompleted

--- a/app/services/notice_service.py
+++ b/app/services/notice_service.py
@@ -2,7 +2,7 @@ import json
 from app.core.llm_client import call_qwen
 from app.model.prompt_template import notice_summary_prompt
 
-def summarize_notice_service(title: str, content: str) -> str:
+async def summarize_notice_service(title: str, content: str) -> str:
     # 공지 요약 프롬프트 구성 (title은 포함하지 않고 content만 사용)
     prompt = notice_summary_prompt.format(docs=content)
 
@@ -18,4 +18,4 @@ def summarize_notice_service(title: str, content: str) -> str:
         isCompleted = False
         summary = "요약 생성 실패"
     
-    return summary, isCompleted
+    return await summary, isCompleted


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
LangChain Community VLLM 래퍼에서 발생한 `IndexError: list index out of range` 문제를 해결하기 위해  
모든 LLM 호출부를 비동기(`async/await`) 기반으로 통일했습니다.

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #55 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. `call_qwen()` → `async def` 및 내부 `await llm.ainvoke()`로 변경
2. `summarize_discord_news_service`, `notice_service` 등 LLM 호출부 비동기화
3. 모든 컨트롤러에서 `await` 호출을 위한 `async def` 선언으로 수정
4. FastAPI 엔드포인트 전체 비동기 체계 유지

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

