### PR TITLE
🐛 fix: userId 타입을 int로 변경

### DIFF
--- a/app/core/chat_history.py
+++ b/app/core/chat_history.py
@@ -34,7 +34,7 @@ class InMemoryHistory(BaseChatMessageHistory, BaseModel):
 
 # 사용자별 메모리
 store = {}
-def get_session_history(userId: str) -> BaseChatMessageHistory:
+def get_session_history(userId: int) -> BaseChatMessageHistory:
     if (userId) not in store:
         store[(userId)] = InMemoryHistory()
     return store[(userId)]

--- a/app/schemas/chat_schema_v2.py
+++ b/app/schemas/chat_schema_v2.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel
 
 class ChatRequest(BaseModel):
     question: str
-    userId : str
+    userId : int
 
 class ChatAnswer(BaseModel):
     answer: str

--- a/app/services/chat_service_v2.py
+++ b/app/services/chat_service_v2.py
@@ -8,12 +8,12 @@ from app.core.chat_history import get_session_history, chat_history_to_string
 retriever = load_vectorstore().as_retriever(search_kwargs={"k": 2})
 
 # 사용자별 세션 히스토리에 Q/A message 저장 
-async def save_chat_history(userId: str, question: str, answer: str):
+async def save_chat_history(userId: int, question: str, answer: str):
     history = get_session_history(userId)
     history.add_user_message(question)
     history.add_ai_message(answer)
 
-async def chat_service(question: str, request_id: str, userId: str) -> str:
+async def chat_service(question: str, request_id: str, userId: int) -> str:
     # 질문 전처리 (상대 날짜 -> 절대 날짜)
     parsed_question = parse_relative_dates(question)
     


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
- 유저 아이디 타입 불일치로 인해 발생한 API 호출 오류를 str에서 int로 수정하며 해결했습니다.

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #91 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. chat_service_v2.py, chat_schema_v2.py, chat_history.py  내 userId를 int 타입으로 통일하여 KeyError 방지

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. FastAPI 서버 실행 후 첫 질문 요청 테스트 → 정상 응답 확인
2. 다양한 userId로 요청 시 KeyError 및 AttributeError 없이 안정적 응답 확인
3. 기존 히스토리 보유 사용자 요청 테스트 → 히스토리 기반 응답 정상 작동

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

- Qwen3가 Qwen2.5보다 히스토리 저장 기능을 잘 활용하지만 한계가 있는 것 같아, 추후에 모델 교체를 고려할 예정이다.
