### PR TITLE
🚑 !HOTFIX: 뉴스 요약/본문 응답 잘림 문제 해결

### DIFF
--- a/app/models/qwen3_loader.py
+++ b/app/models/qwen3_loader.py
@@ -18,6 +18,6 @@ llm = AsyncLLMEngine.from_engine_args(engine_args)
 sampling_params = SamplingParams(
     temperature=0.7,           # 답변 다양성 (우린 정보형 챗봇이라 높을 필요없음)
     top_p=0.8,                 # 핵심 단어 생성 기준
-    max_tokens=512,            # 제한 토큰 수
-    stop=["</s>", "\n\n"]      # 이 토큰이 생성되면 답변 중단
+    max_tokens=1024,           # 제한 토큰 수
+    stop=["</s>"]              # 이 토큰이 생성되면 답변 중단
 )


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
- 기존 Qwen3-8B-AWQ 모델의 응답이 중간에 잘리는 문제가 있어, max_tokens를 512 → 1024로 증가시키고, stop 토큰을 간소화하여 응답 생성 실패 문제를 해결했습니다.

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #119 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. max_tokens 값을 512 → 1024로 증가
2. stop 토큰을 ["</s>", "\n\n\n"] → ["</s>"]로 변경하여 과도한 조기 종료 방지



### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.


