### PR TITLE
♻️ refactor: JSON 파싱 실패 시 HTTP 500 반환하도록 컨트롤러 예외 처리 개선

### DIFF
--- a/app/api/v1/controllers/discordnews_controller.py
+++ b/app/api/v1/controllers/discordnews_controller.py
@@ -1,3 +1,4 @@
+from fastapi import HTTPException
 from app.schemas.discordnews_schema import DiscordNewsRequest, DiscordNewsResponse, DiscordNewsData
 from app.services.discordnews_service import summarize_headiline_discordnews_service
 import uuid
@@ -9,6 +10,13 @@ async def discord_news_controller(request: DiscordNewsRequest) -> DiscordNewsRes
 
     # 뉴스 요약 서비스 호출
     headline, summary, isCompleted = await summarize_headiline_discordnews_service(request.title, request.content, request_id)
+
+    # JSON 파싱 실패 시 500 예외로 전파 
+    if not isCompleted:
+        raise HTTPException(
+            status_code=500,
+            detail="뉴스 헤드라인 및 요약 생성 중 JSON 파싱 오류가 발생했습니다."
+        )
 
     # 표준 응답 스키마로 래핑하여 반환
     return DiscordNewsResponse(

--- a/app/api/v1/controllers/notice_controller.py
+++ b/app/api/v1/controllers/notice_controller.py
@@ -1,3 +1,4 @@
+from fastapi import HTTPException
 from app.services.notice_service import summarize_notice_service
 from app.schemas.notice_schema import NoticeRequest, NoticeResponse, NoticeData
 import uuid
@@ -10,7 +11,14 @@ async def notice_controller(request: NoticeRequest) -> NoticeResponse:
     # 공지사항 요약 서비스 호출
     summary, isCompleted = await summarize_notice_service(request.title, request.content, request_id)
 
-    # 표준 응답 스키마로 래핑하여 반환
+    # JSON 파싱 실패 시 500 예외로 전파 
+    if not isCompleted:
+        raise HTTPException(
+            status_code=500,
+            detail="공지사항 요약 생성 중 JSON 파싱 오류가 발생했습니다."
+        )
+
+    # 정상 응답일 경우 표준 응답 스키마로 래핑하여 반환
     return NoticeResponse(
         message="공지사항 요약이 완료되었습니다.",
         data=NoticeData(summary=summary, isCompleted=isCompleted)

--- a/app/api/v2/controllers/wikinews_controller.py
+++ b/app/api/v2/controllers/wikinews_controller.py
@@ -1,3 +1,4 @@
+from fastapi import HTTPException
 from app.schemas.wikinews_schema import WikiNewsRequest, WikiNewsResponse, WikiNewsData
 from app.services.wikinews_service import generate_wikinews_service
 import uuid
@@ -9,7 +10,14 @@ async def wiki_news_controller(request: WikiNewsRequest) -> WikiNewsResponse:
 
     # 헤드라인, 요약, 뉴스, 이미지 서비스 호출
     headline, summary, news, imageUrl, isCompleted = await generate_wikinews_service(request.title, request.content, request.presignedUrl, request_id)
-
+    
+    # JSON 파싱 실패 시 500 예외로 전파 
+    if not isCompleted:
+        raise HTTPException(
+            status_code=500,
+            detail="위키뉴스 생성 중 JSON 파싱 오류가 발생했습니다."
+        )
+    
     # 표준 응답 스키마로 래핑하여 반환
     return WikiNewsResponse(
         message="뉴스 생성이 완료되었습니다.",

--- a/app/services/chat_service_v3.py
+++ b/app/services/chat_service_v3.py
@@ -27,7 +27,7 @@ def create_faiss_retriever(vectorstore):
     return retriever
 
 # 앙상블 리트리버 생성 함수
-def create_ensemble_retriever(retrievers, weights=[0.7, 0.3]):
+def create_ensemble_retriever(retrievers, weights):
     ensemble_retriever = EnsembleRetriever(
         retrievers=retrievers,
         weights=weights

--- a/app/services/notice_service.py
+++ b/app/services/notice_service.py
@@ -13,7 +13,7 @@ async def summarize_notice_service(title: str, content: str, request_id: str) ->
 
     # LLM 호출
     response = await get_summarize_response(prompt, request_id)
-    isCompleted = True
+    isCompleted = False
 
     # JSON 파싱
     try:

--- a/app/services/notice_service.py
+++ b/app/services/notice_service.py
@@ -13,7 +13,7 @@ async def summarize_notice_service(title: str, content: str, request_id: str) ->
 
     # LLM 호출
     response = await get_summarize_response(prompt, request_id)
-    isCompleted = False
+    isCompleted = True
 
     # JSON 파싱
     try:


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
공지사항 요약 및 뉴스 생성 기능에서 LLM 응답이 JSON 형식이 아닐 경우에도 200 OK 응답이 내려가던 문제를 해결하였습니다.
컨트롤러 단에서 JSON 파싱 실패 시 HTTP 500 예외를 발생시키도록 수정하여, RESTful API 원칙에 맞게 응답 구조를 개선하였습니다.

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #130 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. notice_controller, news_controller 등 주요 컨트롤러에서 isCompleted=False 시 HTTPException(500) 반환 로직 추가
2. 서비스 로직에서 JSON 파싱 실패 시 isCompleted=False로 명시적으로 반환되도록 유지
3. 테스트를 위해 isCompleted=False를 임시 지정 → 이후 다시 True로 원복 처리

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->
![image](https://github.com/user-attachments/assets/977caff6-63f1-4906-9474-79e51d86743b)

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. LLM 응답이 비정상 JSON 형식일 때 500 응답 확인
2. 정상적인 JSON 응답 시 200 OK 및 기대하는 summary 출력 확인
3. 테스트용 isCompleted=False 설정 → 예외 응답 시나리오 확인 후 원복

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->
- 컨트롤러에서 JSON 파싱 실패 시 HTTPException(500)을 명시적으로 던지도록 변경한 이유는, 클라이언트(또는 백엔드 내부 로직)에서 응답 생성 실패 시 재요청 로직을 구현할 수 있도록 하기 위함입니다.
