### PR TITLE
🔀 Merge dev into main: 챗봇 pytest code 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,13 @@ vector/
 
 # Logs
 *.log
+
+# 비공개 키 파일
+keys/
+
+# !/bin/bash
+start.sh
+
+# coverage.py coverage result
+.coverage
+htmlcov/

--- a/app/core/date_utils.py
+++ b/app/core/date_utils.py
@@ -5,6 +5,12 @@ from holidays import Korea
 # 공휴일 입력
 holidays = Korea(years=[2025])
 
+# 마감 키워드가 포함된 문장에서만 마감일을 추가
+DEADLINE_KEYWORDS = ["신청", "접수", "지원", "마감", "등록"]
+
+def contains_deadline_keyword(text: str) -> bool:
+    return any(kw in text for kw in DEADLINE_KEYWORDS)
+
 # 평일 기준 N일 전 날짜 계산 함수
 def subtract_business_days(date: arrow.Arrow, days: int, holidays: set = set()) -> arrow.Arrow:
     count = 0
@@ -18,8 +24,9 @@ def subtract_business_days(date: arrow.Arrow, days: int, holidays: set = set()) 
 # 상대 날짜 문자열 → 절대 날짜로 변환 (그리고 마감일 계산)
 def parse_relative_dates(text: str, tz: str = 'Asia/Seoul') -> str:
     now = arrow.now(tz)
+    weekday_kr = ["월", "화", "수", "목", "금", "토", "일"]
+    add_deadline = contains_deadline_keyword(text)  
 
-    # 기본 날짜 치환 패턴
     patterns = {
         r"오늘": now,
         r"어제": now.shift(days=-1),
@@ -42,17 +49,19 @@ def parse_relative_dates(text: str, tz: str = 'Asia/Seoul') -> str:
         r"다음\s*주\s*일요일": now.floor('week').shift(weeks=+1, days=6),
     }
 
-    weekday_kr = ["월", "화", "수", "목", "금", "토", "일"]
-
     for pattern, date in patterns.items():
         target_date = date.format('YYYY-MM-DD')
         target_weekday = weekday_kr[date.weekday()]
-        deadline_date = subtract_business_days(date, 3, holidays)
-        deadline_fmt = deadline_date.format('YYYY-MM-DD')
-        deadline_weekday = weekday_kr[deadline_date.weekday()]
-        replacement = f"{target_date} ({target_weekday}) (신청 마감: {deadline_fmt} ({deadline_weekday}))"
+        replacement = f"{target_date} ({target_weekday})"
+
+        if add_deadline:
+            deadline_date = subtract_business_days(date, 3, holidays)
+            deadline_fmt = deadline_date.format('YYYY-MM-DD')
+            deadline_weekday = weekday_kr[deadline_date.weekday()]
+            replacement += f" (신청 마감: {deadline_fmt} ({deadline_weekday}))"
+
         text = re.sub(pattern, replacement, text)
-        
+
     # 특정 날짜 인식 (예 : 6월 5일)
     date_patterns = re.findall(r"(?:(\d{4})년\s*)?(\d{1,2})월\s*(\d{1,2})일", text)
 
@@ -64,11 +73,15 @@ def parse_relative_dates(text: str, tz: str = 'Asia/Seoul') -> str:
             date = arrow.get(f"{year}-{month:02d}-{day:02d}")
             target = date.format('YYYY-MM-DD')
             weekday = weekday_kr[date.weekday()]
-            deadline = subtract_business_days(date, 3, holidays)
-            deadline_fmt = deadline.format('YYYY-MM-DD')
-            deadline_weekday = weekday_kr[deadline.weekday()]
+            replacement = f"{target} ({weekday})"
+
+            if add_deadline:
+                deadline = subtract_business_days(date, 3, holidays)
+                deadline_fmt = deadline.format('YYYY-MM-DD')
+                deadline_weekday = weekday_kr[deadline.weekday()]
+                replacement += f" (신청 마감: {deadline_fmt} ({deadline_weekday}))"
+
             original = f"{match[0]+'년 ' if match[0] else ''}{month}월 {day}일"
-            replacement = f"{target} ({weekday}) (신청 마감: {deadline_fmt} ({deadline_weekday}))"
             text = text.replace(original, replacement)
         except Exception:
             continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,6 @@ holidays==0.46
 accelerate
 torch
 rank_bm25>=0.2.2
+pytest
+pytest-asyncio
+httpx

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -1,0 +1,55 @@
+import pytest
+import asyncio
+import httpx
+import time
+import os
+from dotenv import load_dotenv
+
+# .env 파일에서 환경 변수 불러오기
+load_dotenv()
+
+@pytest.mark.asyncio
+async def test_chat_stream():
+    # 요청에 사용할 데이터 정의 (예: 사용자 ID와 질문)
+    payload = {
+        "userId": 1234,
+        "question": "최근 공지사항 알려줘"
+    }
+
+    # 환경 변수에서 API 엔드포인트 URL 불러오기
+    url = os.getenv("CHAT_API_URL")
+
+    # 요청 헤더 정의 (JSON 형식으로 전송)
+    headers = {
+        "Content-Type": "application/json"
+    }
+
+    # httpx 비동기 클라이언트로 SSE 요청 수행
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        # 전체 요청~응답 시간 측정을 위한 시작 시간 기록
+        start_time = time.perf_counter()
+
+        # SSE 방식으로 POST 요청 보내고 응답 스트림 처리
+        async with client.stream("POST", url, json=payload, headers=headers) as response:
+            # 응답 상태 코드 확인
+            assert response.status_code == 200
+            # Content-Type이 SSE인지 확인
+            assert response.headers["content-type"].startswith("text/event-stream")
+
+            full_data = ""  # 전체 스트림 데이터를 누적할 변수
+            async for line in response.aiter_lines():
+                # 실제 데이터 라인이면 "data: " 접두어 제거하고 저장
+                if line.startswith("data: "):
+                    chunk = line.removeprefix("data: ").strip()
+                    print(chunk, end="", flush=True)
+                    full_data += chunk
+                # 스트림 종료 이벤트 감지
+                elif line.startswith("event: end_of_stream"):
+                    break
+
+        # 응답 시간 측정 종료
+        elapsed = time.perf_counter() - start_time
+        print(f"\n\n🧪 총 응답 시간: {elapsed:.2f}초")
+
+        # 전체 데이터가 비어있지 않아야 함
+        assert len(full_data.strip()) > 0


### PR DESCRIPTION
### Description

GCP 서버에 VSCode Remote-SSH를 활용해 원격 개발 환경을 구성하고, FastAPI SSE 엔드포인트에 대한 `pytest` 기반 자동화 테스트 코드를 작성하였습니다.

FastAPI 서버를 재시작하지 않고도 테스트 디버깅이 가능하도록 `stream` 테스트 코드를 구성하여 개발 생산성과 테스트 효율성을 향상시켰습니다.

### Related Issues

- Resolves #53 

### Changes Made

1. GCP 인스턴스에 SSH 접근 후 VSCode Remote 환경 구성
2. FastAPI 서버 실행 상태에서 중단 없이 테스트 가능하도록 `httpx.AsyncClient.stream()` 기반 테스트 코드 작성
3. `tests/test_chat_api.py` 내 `test_chat_stream()` 테스트 함수 작성 및 주석 추가
4. SSE 스트림 응답 데이터 전체 수신 및 시간 측정 로직 구현
5. `.coverage` 커버리지 파일 및 `htmlcov/` 디렉토리를 `.gitignore`에 추가하여 Git 추적에서 제외

### Screenshots or Video

테스트 실행 예시:
```bash
$ pytest tests/test_chat_api.py -s
```
<img width="801" alt="스크린샷 2025-07-08 15 08 03" src="https://github.com/user-attachments/assets/a4e52985-921e-4486-bf1e-16db5e120997" />

### Testing
1. GCP 서버에서 VSCode Remote로 접속
2. .env에 CHAT_API_URL을 환경변수로 등록
3. FastAPI 서버가 실행된 상태에서 pytest 실행
4. SSE 스트리밍 응답을 수신하고 유효성을 검증 (status_code, content-type, 데이터 누적 길이 등)
5. FastAPI 서버 재시작 없이 반복 테스트 성공
6. `coverage run -m pytest` 실행 결과, 해당 테스트 코드로 주요 흐름이 50% 커버됨을 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes
- VSCode Remote 환경에서 테스트 흐름을 완전히 자동화했기 때문에, FastAPI 서버 재시작 없이 디버깅 및 반복 테스트가 가능합니다.
- 커버리지 측정 시 .coverage 파일이 생성되므로 .gitignore에 해당 항목을 추가해 버전 관리에서 제외했습니다.